### PR TITLE
Update SPH-Exchange-MailboxSize.ps1

### DIFF
--- a/agents/plugins/SPH-Exchange-MailboxSize.ps1
+++ b/agents/plugins/SPH-Exchange-MailboxSize.ps1
@@ -20,9 +20,9 @@ add-PSSnapin Microsoft.Exchange.Management.PowerShell.E2010
 #Export-CSV C:\CMK-MailboxReport.csv -NTI}
 
 # filename for timestamp
-$remote_host = $env:REMOTE_HOST
+$remote_host_tmp = $env:REMOTE_HOST
 $agent_dir   = $env:MK_CONFDIR
-
+$remote_host = $remote_host_tmp  -replace ":","."
 $timestamp = $agent_dir + "\timestamp."+ $remote_host
 
 # execute agent only every $delay seconds - 24 hours


### PR DESCRIPTION
In my case the script failed because $remote_host was an ipv6 address. With the -replace it works even for those.